### PR TITLE
Removed null strings from list iterated through when uploaded to db

### DIFF
--- a/R/scrape.R
+++ b/R/scrape.R
@@ -281,8 +281,10 @@ scrape <- function(start, end, game.ids, suffix = "inning/inning_all.xml", conne
       tables[["pitch"]] <- appendPitchCount(tables[["pitch"]])
       tables[["atbat"]] <- appendDate(tables[["atbat"]])
       if (!missing(connect)) {
+        table_names <- names(tables)
+        table_names <- table_names[!(table_names %in% '')]
         #Try to write tables to database, if that fails, write to csv. Then clear up memory
-        for (i in names(tables)) export(connect, name = i, value = tables[[i]], template = fields[[i]])
+        for (i in table_names) export(connect, name = i, value = tables[[i]], template = fields[[i]])
         rm(tables)
         message("Collecting garbage")
         gc()


### PR DESCRIPTION

The following error has come up in a couple issues (#30, #33):
`Error in names(value) <- sub("\\.", "_", names(value)) :
  attempt to set an attribute on NULL`

Sample code used to generate the error:

`db <- src_sqlite("data/external/pitchfx.sqlite3", create = T)
scrape(start = "2017-04-01", end = as.character("2017-04-02"), connect = db$con)`

This error only occurs when the `scrape` function is attempting to upload the tables to the designated database ([line 285 in scrape.py](https://github.com/cpsievert/pitchRx/blob/master/R/scrape.R#L285)).  Currently names(tables) returns a 7 item list with 2 attributes names equal to null `''`

If we inspect `names(tables)' at that line, we get the following:

`Browse[1]> names(tables)
[1] ""       "atbat"  "action" "pitch"  "po"     "runner" ""  `

The job fails when `""` is iterated over.  This pull fixed the issue by removing all `""` in the iterated list.  